### PR TITLE
Minimal Redis backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: node_js
+
+node_js:
+    - '0.10'
+
+services:
+    - redis-server
+
+script:
+    - npm install juttle/juttle
+    - mocha

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,13 @@
+var redis_utils = require('./utils');
+
+function RedisBackend(config) {
+    redis_utils.init(config);
+
+    return {
+        name: 'redis',
+        read: require('./read'),
+        write: require('./write')
+    };
+}
+
+module.exports = RedisBackend;

--- a/lib/read.js
+++ b/lib/read.js
@@ -1,0 +1,41 @@
+var Promise = require('bluebird');
+
+var Juttle = require('juttle/lib/runtime').Juttle;
+var utils = require('./utils');
+var transformations = require('./redis-result-transformation-functions');
+
+var Read = Juttle.proc.base.extend({
+    procName: 'redis_read',
+    sourceType: 'batch',
+
+    initialize: function(options, params) {
+        if (!options.hasOwnProperty('raw')) {
+            throw new Error('must specify a redis query with -raw');
+        }
+
+        this.command = options.raw.split(' ');
+    },
+
+    start: function() {
+        var self = this;
+        var keyword = this.command[0].toLowerCase();
+
+        if (!transformations.hasOwnProperty(keyword)) {
+            return self.trigger('error', new Error('unsupported/invalid Redis command: ', keyword));
+        }
+        return utils.get_redis_client().then(function(redis) {
+            return redis.rawCallAsync(self.command);
+        })
+        .then(function(result) {
+            var points = transformations[keyword](self.command, result);
+
+            self.emit(points);
+            self.emit_eof();
+        })
+        .catch(function(err) {
+            self.trigger('error', new Error(err.message));
+        });
+    }
+});
+
+module.exports = Read;

--- a/lib/redis-result-transformation-functions.js
+++ b/lib/redis-result-transformation-functions.js
@@ -1,0 +1,17 @@
+// Reading from Redis always returns a flat array
+// this file contains rules for transforming these
+// arrays into arrays of Juttle points given
+// a command and its output
+
+module.exports = {
+    hmget: function(command, result) {
+        var output = {};
+        var fields = command.slice(2);
+        var values = result[0];
+        for (var i = 0; i < fields.length; i++) {
+            output[fields[i]] = values[i];
+        }
+
+        return [output];
+    }
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,23 @@
+var Promise = require('bluebird');
+var Redis = require('redis-fast-driver');
+
+var redis_promise;
+
+function get_redis_client() {
+    return redis_promise;
+}
+
+function init(config) {
+    var redis = Promise.promisifyAll(new Redis(config));
+    redis_promise = new Promise(function(resolve, reject) {
+        redis.on('ready', function() {
+            resolve(redis);
+        });
+        redis.on('error', reject);
+    });
+}
+
+module.exports = {
+    init: init,
+    get_redis_client: get_redis_client
+};

--- a/lib/write.js
+++ b/lib/write.js
@@ -1,0 +1,42 @@
+var Promise = require('bluebird');
+
+var Juttle = require('juttle/lib/runtime').Juttle;
+var utils = require('./utils');
+
+var Write = Juttle.proc.sink.extend({
+    procName: 'redis_write',
+    initialize: function(options) {
+        var self = this;
+        this.in_progress_writes = 0;
+    },
+    process: function(points) {
+        var self = this;
+        this.in_progress_writes++;
+        utils.get_redis_client().then(function(redis) {
+            return Promise.map(points, function(pt) {
+                if (pt.hasOwnProperty('redis_write_command')) {
+                    var command = pt.redis_write_command.split(' ');
+                    return redis.rawCallAsync(command)
+                        .catch(function(err) {
+                            self.trigger('error', 'bad write command: ' + JSON.stringify(command) + ': ' + err.message);
+                        });
+                }
+            });
+        })
+        .finally(function() {
+            self.in_progress_writes--;
+            self._maybe_done();
+        });
+    },
+    _maybe_done: function() {
+        if (this.in_progress_writes === 0) {
+            this.emit_eof();
+            this.done();
+        }
+    },
+    eof: function(from) {
+        this._maybe_done();
+    }
+});
+
+module.exports = Write;

--- a/package.json
+++ b/package.json
@@ -11,5 +11,13 @@
     "redis"
   ],
   "author": "Dave Galbraith",
-  "license": "ISC"
+  "license": "ISC",
+  "dependencies": {
+    "bluebird": "^2.9.34",
+    "bluebird-retry": "^0.5.2",
+    "chai": "^3.4.1",
+    "mocha": "^2.3.4",
+    "redis-fast-driver": "^0.1.2",
+    "underscore": "^1.8.3"
+  }
 }

--- a/test/redis-backend.spec.js
+++ b/test/redis-backend.spec.js
@@ -1,0 +1,46 @@
+var _ = require('underscore');
+var Promise = require('bluebird');
+var retry = require('bluebird-retry');
+var expect = require('chai').expect;
+var util = require('util');
+
+var juttle_test_utils = require('juttle/test/runtime/specs/juttle-test-utils');
+var check_juttle = juttle_test_utils.check_juttle;
+var Juttle = require('juttle/lib/runtime').Juttle;
+var Redis = require('../lib');
+var test_utils = require('./redis-test-utils');
+
+var backend = Redis({
+    address: 'localhost',
+    port: 6379
+}, Juttle);
+
+Juttle.backends.register(backend.name, backend);
+
+describe('redis source', function() {
+    this.timeout(300000);
+
+    describe('HMSET/HMGET', function() {
+        var points = [{a: '1', id: 'test', time: new Date().toISOString()}];
+
+        it('writes points with HMSET', function() {
+            var program = util.format('emit -points %s | put redis_write_command = "HMSET ${id} a ${a} time ${time}" | write redis', JSON.stringify(points));
+            return check_juttle({
+                program: program
+            });
+        });
+
+        it('reads points with HMGET', function() {
+            var program = 'read redis -raw "HMGET test a time"';
+            return check_juttle({
+                program: program
+            })
+            .then(function(result) {
+                var expected = points.map(function(point) {
+                    return _.omit(point, 'id');
+                });
+                expect(result.sinks.table).deep.equal(expected);
+            });
+        });
+    });
+});

--- a/test/redis-test-utils.js
+++ b/test/redis-test-utils.js
@@ -1,0 +1,26 @@
+var Promise = require('bluebird');
+var _ = require('underscore');
+var util = require('util');
+var expect = require('chai').expect;
+var retry = require('bluebird-retry');
+var Redis = require('redis-fast-driver');
+
+var test_client = Promise.promisifyAll(new Redis({
+    host: '127.0.0.1',
+    port: 6379
+}));
+
+var connect_promise = new Promise(function(resolve, reject) {
+    test_client.on('ready', resolve);
+    test_client.on('error', reject);
+});
+
+function clear_redis() {
+    return connect_promise.then(function() {
+        return test_client.rawCallAsync(['FLUSHALL']);
+    });
+}
+
+module.exports = {
+    clear_redis: clear_redis,
+};


### PR DESCRIPTION
All it supports is HMSET and HMGET, but it has the infrastructure to add more commands. I'll get working on that presently, but opening this up for review now. See https://jut-io.atlassian.net/wiki/display/JUT20/Jut+for+Redis for the full plan.

The driver we use only works on 0.10 until the Guy merges https://github.com/h0x91b/redis-fast-driver/pull/2. Can't seem to `npm install juttle/juttle` with 0.10, so Travis is grumpy.

@demmer @VladVega @bkutil